### PR TITLE
Fix import paths and route setup

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -9,4 +9,10 @@ port = int(os.getenv("APP_PORT", "8080"))
 reload_opt = os.getenv("APP_RELOAD", "false").lower() == "true"
 
 if __name__ == "__main__":
-    uvicorn.run("app.main:app", host=host, port=port, reload=reload_opt)
+    # ``app.main`` no longer exists.  The FastAPI application instance is
+    # created in ``app/api/__init__.py`` and can be imported as
+    # ``app.api:app``.  Using the old import path resulted in ``uvicorn``
+    # failing to start with ``Error loading ASGI app`` because the module did
+    # not exist.  Point ``uvicorn`` to the correct location so running
+    # ``python -m app`` boots the service as expected.
+    uvicorn.run("app.api:app", host=host, port=port, reload=reload_opt)

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,4 +1,4 @@
-from config import (
+from app.config import (
     CONVERSATIONS_DIR,
     MAX_HISTORY_MESSAGES,
     MODEL_NAME,
@@ -7,9 +7,9 @@ from config import (
 from fastapi import FastAPI
 from openai import OpenAI
 
-from app.routes import router
+from app.api.routes import router
 from app.services.chat import ChatService
-from app.storage.conversation_store import ConversationStore
+from app.services.conversation_store import ConversationStore
 from app.utils.prompt_loader import PromptLoader
 
 

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -8,6 +8,15 @@ import httpx
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
+from app.config import (
+    ORS_API_KEY,
+    ORS_DIRECTIONS_URL,
+    REV_GEOCODER_CONCURRENCY,
+    YANDEX_GEOCODER_API_KEY,
+    YANDEX_GEOCODER_URL,
+)
+from app.api.schemas import OptionsIn, PointIn, StepOut, ViaLocality
+
 # HTTP клиенты
 _http_timeout = httpx.Timeout(25.0, connect=15.0)
 geocoder_client = httpx.AsyncClient(timeout=_http_timeout)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,9 +1,27 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from app.api.schemas import ChatRequest, ChatResponse, HealthResponse, RouteResponse
+from app.api.main import (
+    annotate_intermediate_localities,
+    build_markdown,
+    ensure_coords,
+    enrich_localities_with_yandex,
+    ors_extract_steps,
+    ors_route,
+)
+from app.api.schemas import (
+    ChatRequest,
+    ChatResponse,
+    HealthResponse,
+    OptionsIn,
+    RouteRequest,
+    RouteResponse,
+)
 from app.services.chat import ChatService
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def get_chat_service(request: Request) -> ChatService:
@@ -31,7 +49,7 @@ def chat(req: ChatRequest, svc: ChatService = Depends(get_chat_service)):
 # -------------------- Эндпоинт --------------------
 
 
-@app.post("/route", response_model=RouteResponse)
+@router.post("/route", response_model=RouteResponse)
 async def route(req: RouteRequest) -> RouteResponse:
     try:
         a_lat, a_lon, a_label = await ensure_coords(req.a)

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,6 +1,6 @@
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 Role = Literal["system", "user", "assistant"]
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 # Сетевые параметры
@@ -12,11 +13,15 @@ CONVERSATIONS_DIR: Path = Path("conversations")
 # Прочие настройки (можете расширять по необходимости)
 MAX_HISTORY_MESSAGES: int | None = None  # например, ограничение «окна» истории
 
-OPENAI_API_KEY = ""
-YANDEX_GEOCODER_API_KEY = ""
-ORS_API_KEY = ""
-PROMPT_PATH = ""
-OUT_PATH = ""
+# Значения берутся из окружения. Ранее переменные были пустыми строками,
+# из-за чего приложение сразу падало с ``RuntimeError``, даже если
+# соответствующие переменные окружения были заданы при запуске. Читаем
+# значения через ``os.getenv``.
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+YANDEX_GEOCODER_API_KEY = os.getenv("YANDEX_GEOCODER_API_KEY", "")
+ORS_API_KEY = os.getenv("ORS_API_KEY", "")
+PROMPT_PATH = os.getenv("PROMPT_PATH", "")
+OUT_PATH = os.getenv("OUT_PATH", "")
 
 # -------------------- Конфигурация --------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.111
 uvicorn>=0.29
 httpx>=0.27
 pydantic>=2.7
+openai>=1.0


### PR DESCRIPTION
## Summary
- fix __main__ entrypoint to load `app.api` module
- correct imports and router usage in API modules
- load API keys from environment in config and add OpenAI dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `YANDEX_GEOCODER_API_KEY=dummy ORS_API_KEY=dummy OPENAI_API_KEY=dummy timeout 5 python -m app`

------
https://chatgpt.com/codex/tasks/task_e_68a23852aef4833080f9f06ce45abd61