### PR TITLE
refactor: load settings from env file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn>=0.29
 httpx>=0.27
 pydantic>=2.7
 openai>=1.0
+loguru>=0.7
+pydantic-settings>=2.0


### PR DESCRIPTION
## Summary
- load configuration via a pydantic `Settings` class
- add loguru-based logger setup
- declare new dependencies `loguru` and `pydantic-settings`

## Testing
- `pytest`
- `YANDEX_GEOCODER_API_KEY=dummy ORS_API_KEY=dummy python - <<'PY'
from app.config import settings
print('geocoder', settings.yandex_geocoder_api_key)
print('ors', settings.ors_api_key)
print('logger level', settings.log_lvl)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a23defd3288330b426557b58688395