### PR TITLE
Refactor OpenAI client integration

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -2,15 +2,16 @@ from app.config import (
     CONVERSATIONS_DIR,
     MAX_HISTORY_MESSAGES,
     MODEL_NAME,
+    OPENAI_API_KEY,
     SYSTEM_PROMPT_PATH,
 )
 from fastapi import FastAPI
-from openai import OpenAI
 
 from app.api.routes import router
 from app.services.chat import ChatService
 from app.services.conversation_store import ConversationStore
 from app.utils.prompt_loader import PromptLoader
+from app.integration.chatgpt import OpenAIClient
 
 
 def create_app() -> FastAPI:
@@ -18,14 +19,13 @@ def create_app() -> FastAPI:
 
     @app.on_event("startup")
     def _startup():
-        client = OpenAI()  # берет OPENAI_API_KEY из окружения
+        client = OpenAIClient(api_key=OPENAI_API_KEY, model_name=MODEL_NAME)
         prompt_loader = PromptLoader(SYSTEM_PROMPT_PATH)
         store = ConversationStore(CONVERSATIONS_DIR)
         chat_service = ChatService(
             client=client,
             prompt_loader=prompt_loader,
             store=store,
-            model_name=MODEL_NAME,
             max_history_messages=MAX_HISTORY_MESSAGES,
         )
         app.state.chat_service = chat_service

--- a/app/services/chat.py
+++ b/app/services/chat.py
@@ -1,10 +1,9 @@
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
-from openai import OpenAI
-
+from app.integration.chatgpt import OpenAIClient
 from app.services.conversation_store import ConversationStore
 from app.utils.prompt_loader import PromptLoader
 
@@ -32,17 +31,16 @@ class ChatService:
 
     def __init__(
         self,
-        client: OpenAI,
+        client: OpenAIClient,
         prompt_loader: PromptLoader,
         store: ConversationStore,
-        model_name: str,
         max_history_messages: Optional[int] = None,
     ):
         self.client = client
         self.prompt_loader = prompt_loader
         self.store = store
-        self.model_name = model_name
         self.max_history_messages = max_history_messages
+        self.model_name = client.model_name
 
     def _build_messages(
         self, system_prompt: str, history: List[Dict[str, Any]], new_user_text: str
@@ -90,10 +88,7 @@ class ChatService:
 
         msgs = self._build_messages(system_prompt, history, user_text)
 
-        resp = self.client.responses.create(
-            model=self.model_name,
-            input=msgs,
-        )
+        resp = self.client.create(msgs)
         assistant_text = resp.output_text
         response_id = getattr(resp, "id", None)
 


### PR DESCRIPTION
## Summary
- wrap OpenAI Responses API in new `OpenAIClient` class
- refactor chat service to use the new client
- wire `OpenAIClient` into API startup

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a23fa991188330b38b6100a37c02b0