### PR TITLE
Sanitize chat IDs and cleanup http clients

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -8,6 +8,7 @@ from app.config import (
 from fastapi import FastAPI
 
 from app.api.routes import router
+from app.api.main import close_http_clients
 from app.services.chat import ChatService
 from app.services.conversation_store import ConversationStore
 from app.utils.prompt_loader import PromptLoader
@@ -31,6 +32,7 @@ def create_app() -> FastAPI:
         app.state.chat_service = chat_service
 
     app.include_router(router, prefix="/api")
+    app.add_event_handler("shutdown", close_http_clients)
     return app
 
 

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -5,7 +5,7 @@ import os
 from typing import Dict, List, Optional, Tuple
 
 import httpx
-from fastapi import FastAPI, HTTPException
+from fastapi import HTTPException
 from pydantic import BaseModel, Field, model_validator
 
 from app.config import (
@@ -25,8 +25,6 @@ ors_client = httpx.AsyncClient(timeout=_http_timeout)
 # Логирование
 logging.basicConfig(level=os.getenv("LOGLEVEL", "INFO"))
 log = logging.getLogger("route-api")
-
-app = FastAPI(title="Route Text API (Yandex Geocoder + ORS)", version="1.1.0")
 
 # -------------------- Утилиты форматирования/геометрии --------------------
 
@@ -441,7 +439,6 @@ async def ensure_coords(p: PointIn) -> Tuple[float, float, str]:
 # -------------------- Грейсфул шатдаун --------------------
 
 
-@app.on_event("shutdown")
-async def _shutdown():
+async def close_http_clients() -> None:
     await geocoder_client.aclose()
     await ors_client.aclose()

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -14,7 +14,6 @@ from app.api.schemas import (
     ChatRequest,
     ChatResponse,
     HealthResponse,
-    OptionsIn,
     RouteRequest,
     RouteResponse,
 )
@@ -38,7 +37,8 @@ def healthcheck():
 
 @router.post("/chat", response_model=ChatResponse)
 def chat(req: ChatRequest, svc: ChatService = Depends(get_chat_service)):
-    result = svc.chat(user_text=req.user_text, conversation_id=req.conversation_id)
+    conv_id = str(req.conversation_id) if req.conversation_id else None
+    result = svc.chat(user_text=req.user_text, conversation_id=conv_id)
     return ChatResponse(
         conversation_id=result.conversation_id,
         assistant_text=result.assistant_text,
@@ -55,7 +55,7 @@ async def route(req: RouteRequest) -> RouteResponse:
         a_lat, a_lon, a_label = await ensure_coords(req.a)
         b_lat, b_lon, b_label = await ensure_coords(req.b)
 
-        data = await ors_route(a_lat, a_lon, b_lat, b_lon, req.options or OptionsIn())
+        data = await ors_route(a_lat, a_lon, b_lat, b_lon, req.options)
         steps, total_m, total_s, coords, step_bounds = ors_extract_steps(data)
 
         if not steps:

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,4 +1,5 @@
 from typing import List, Literal, Optional
+from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -7,7 +8,7 @@ Role = Literal["system", "user", "assistant"]
 
 class ChatRequest(BaseModel):
     user_text: str = Field(..., description="Свежий ввод пользователя")
-    conversation_id: Optional[str] = Field(
+    conversation_id: Optional[UUID] = Field(
         None, description="UUID/идентификатор диалога"
     )
 
@@ -64,7 +65,7 @@ class ViaLocality(BaseModel):
 class RouteRequest(BaseModel):
     a: PointIn
     b: PointIn
-    options: Optional[OptionsIn] = OptionsIn()
+    options: OptionsIn = Field(default_factory=OptionsIn)
 
 
 class StepOut(BaseModel):


### PR DESCRIPTION
## Summary
- validate chat conversation IDs as UUIDs
- close external HTTP clients on shutdown
- use per-request routing options and sanitize chat IDs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a248d036d48330be0c07db914591ac